### PR TITLE
Generate src/types from deps/perpdex-contract.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/perpdex-contract"]
+	path = deps/perpdex-contract
+	url = https://github.com/perpdex/perpdex-contract.git

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
+        "build-contract": "cd deps/perpdex-contract && npm install && npm run build",
         "generate-type": "ts-node script/generate-type.ts",
         "postinstall": "typesync",
         "prepare": "husky install",

--- a/script/generate-type.ts
+++ b/script/generate-type.ts
@@ -9,7 +9,7 @@ async function main() {
         new TypeChain({
             cwd,
             rawConfig: {
-                files: `${__dirname}/../node_modules/@perp/contract/build/contracts/!(build-info)/**/+([a-zA-Z0-9_]).json`,
+                files: `${__dirname}/../deps/perpdex-contract/artifacts/contracts/**/+([a-zA-Z0-9_]).json`,
                 outDir: "src/types/contracts",
                 target: "ethers-v5",
             },


### PR DESCRIPTION
Generate src/types from deps/perpdex-contract.

## Generate types

```bash
git submodule update --init --recursive
npm run build-contract
npm run generate-type
```

## ABI location

deps/perpdex-contract/artifacts/contracts