### PR TITLE
tv charting library

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,3 +21,47 @@ jobs:
       - run: yarn build
         env:
           CI: false
+
+  build-with-charting-library:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      # fix SSH error: git@github.com: Permission denied (publickey).
+      # copy from https://github.com/actions/setup-node/issues/214#issuecomment-810829250
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+
+      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.CHARTING_LIBRARY_DEPLOY_KEY }}
+      - run: git clone git@github.com:perpdex/charting_library.git /tmp/charting_library
+
+      - run: yarn build-contract
+      - run: yarn install
+      - run: yarn build
+        env:
+          CI: false
+          CHARTING_LIBRARY_PATH: /tmp/charting_library

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,37 +30,18 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      # fix SSH error: git@github.com: Permission denied (publickey).
-      # copy from https://github.com/actions/setup-node/issues/214#issuecomment-810829250
-      - name: Reconfigure git to use HTTP authentication
-        run: >
-          git config --global url."https://github.com/".insteadOf
-          ssh://git@github.com/
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: yarn
 
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.CHARTING_LIBRARY_DEPLOY_KEY }}
       - run: git clone git@github.com:perpdex/charting_library.git /tmp/charting_library
 
-      - run: yarn build-contract
       - run: yarn install
+      - run: yarn build-contract-all
       - run: yarn build
         env:
           CI: false

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 /.vscode
 
 !.gitkeep
+
+/public/charting_library
+/public/datafeeds

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "private": true,
     "scripts": {
         "start": "react-scripts start",
-        "prebuild": "run-p export-deployment export-deployment-stablecoin generate-type",
+        "prebuild": "run-p export-deployment export-deployment-stablecoin generate-type copy-charting-library",
         "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
@@ -19,6 +19,7 @@
         "postinstall": "typesync",
         "prepare": "husky install",
         "deploy-ipfs": "npx ipfs-deploy@v11.2.2 build",
+        "copy-charting-library": "bash script/copy_charting_library.sh",
         "clean": "rm -rf src/types"
     },
     "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,7 @@
     -->
     <title>PerpDEX</title>
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <script src="%PUBLIC_URL%/charting_library/charting_library.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,7 @@
     <title>PerpDEX</title>
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
     <script src="%PUBLIC_URL%/charting_library/charting_library.js"></script>
+    <script src="%PUBLIC_URL%/datafeeds/udf/dist/bundle.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/script/copy_charting_library.sh
+++ b/script/copy_charting_library.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+rm -rf public/charting_library
+rm -rf public/datafeeds
+
+if [[ -z "${CHARTING_LIBRARY_PATH}" ]]; then
+  echo 'skip copy trading view charting library because $CHARTING_LIBRARY_PATH env var not exist'
+else
+  cp -r $CHARTING_LIBRARY_PATH/charting_library public/charting_library
+  cp -r $CHARTING_LIBRARY_PATH/datafeeds public/datafeeds
+fi

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -4,3 +4,5 @@ export * from "./position"
 export * from "./stage"
 export * from "./storage"
 export * from "./wallet"
+
+export const isTechnicalChart = !!(window as any).TradingView

--- a/src/page/Trade/TechnicalChart/index.tsx
+++ b/src/page/Trade/TechnicalChart/index.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { PerpdexMarketContainer } from "container/connection/perpdexMarketContainer"
+import { Connection } from "container/connection"
+import { TVChartContainer } from "../../../tradingView/TVChartContainer"
+
+function TechnicalChart() {
+    const { currentMarketState, marketStates } = PerpdexMarketContainer.useContainer()
+    const { chainId } = Connection.useContainer()
+
+    // const datafeed = useMemo(
+    //     () => {
+    //
+    //     },
+    //     [currentMarketState.address, currentMarketState.inverse],
+    // )
+
+    const datafeed = new (window as any).Datafeeds.UDFCompatibleDatafeed("https://demo_feed.tradingview.com")
+
+    return <TVChartContainer datafeed={datafeed}></TVChartContainer>
+}
+
+export default TechnicalChart

--- a/src/page/Trade/TechnicalChart/index.tsx
+++ b/src/page/Trade/TechnicalChart/index.tsx
@@ -1,22 +1,27 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { PerpdexMarketContainer } from "container/connection/perpdexMarketContainer"
 import { Connection } from "container/connection"
 import { TVChartContainer } from "../../../tradingView/TVChartContainer"
+import { createDataFeed } from "../../../tradingView/datafeed"
 
 function TechnicalChart() {
-    const { currentMarketState, marketStates } = PerpdexMarketContainer.useContainer()
-    const { chainId } = Connection.useContainer()
+    const { currentMarketState } = PerpdexMarketContainer.useContainer()
+    const { signer } = Connection.useContainer()
 
-    // const datafeed = useMemo(
-    //     () => {
-    //
-    //     },
-    //     [currentMarketState.address, currentMarketState.inverse],
-    // )
+    const datafeed = useMemo(() => {
+        return createDataFeed({
+            signer: signer,
+            marketState: currentMarketState,
+        })
+    }, [signer, currentMarketState.address, currentMarketState.inverse])
 
-    const datafeed = new (window as any).Datafeeds.UDFCompatibleDatafeed("https://demo_feed.tradingview.com")
+    const isMarketReady = useMemo(() => currentMarketState.name, [currentMarketState.name])
 
-    return <TVChartContainer datafeed={datafeed}></TVChartContainer>
+    if (isMarketReady) {
+        return <TVChartContainer symbol={currentMarketState.name || "AAPL"} datafeed={datafeed} />
+    }
+
+    return <div className="tv_chart_loading">Loading...</div>
 }
 
 export default TechnicalChart

--- a/src/page/Trade/index.tsx
+++ b/src/page/Trade/index.tsx
@@ -9,6 +9,7 @@ import LightWeightChart from "./LightWeightChart"
 import OrderHistory from "./OrderHistory"
 import AccountSummary from "./AccountSummary"
 import OrderBook from "./OrderBook"
+import { TVChartContainer } from "../../tradingView/TVChartContainer"
 
 function Trade() {
     const [height, setHeight] = useState<number | undefined>(0)
@@ -20,6 +21,8 @@ function Trade() {
         }
     }, [])
 
+    const datafeed = new (window as any).Datafeeds.UDFCompatibleDatafeed("https://demo_feed.tradingview.com")
+
     return (
         <FrameContainer removeMarginTop>
             <Flex direction={{ base: "column", lg: "row" }}>
@@ -27,6 +30,9 @@ function Trade() {
                     <Flex direction={{ base: "column", lg: "row" }} alignItems="flex-start">
                         <VStack alignItems="stretch">
                             <ChartHead />
+                            <Box width={600} height={400}>
+                                <TVChartContainer datafeed={datafeed} />
+                            </Box>
                             <Box width={600} height={400}>
                                 <LightWeightChart />
                             </Box>

--- a/src/page/Trade/index.tsx
+++ b/src/page/Trade/index.tsx
@@ -9,7 +9,8 @@ import LightWeightChart from "./LightWeightChart"
 import OrderHistory from "./OrderHistory"
 import AccountSummary from "./AccountSummary"
 import OrderBook from "./OrderBook"
-import { TVChartContainer } from "../../tradingView/TVChartContainer"
+import TechnicalChart from "./TechnicalChart"
+import { isTechnicalChart } from "../../constant"
 
 function Trade() {
     const [height, setHeight] = useState<number | undefined>(0)
@@ -21,8 +22,6 @@ function Trade() {
         }
     }, [])
 
-    const datafeed = new (window as any).Datafeeds.UDFCompatibleDatafeed("https://demo_feed.tradingview.com")
-
     return (
         <FrameContainer removeMarginTop>
             <Flex direction={{ base: "column", lg: "row" }}>
@@ -31,10 +30,7 @@ function Trade() {
                         <VStack alignItems="stretch">
                             <ChartHead />
                             <Box width={600} height={400}>
-                                <TVChartContainer datafeed={datafeed} />
-                            </Box>
-                            <Box width={600} height={400}>
-                                <LightWeightChart />
+                                {isTechnicalChart ? <TechnicalChart /> : <LightWeightChart />}
                             </Box>
                         </VStack>
                         <OrderHistory />

--- a/src/tradingView/TVChartContainer.tsx
+++ b/src/tradingView/TVChartContainer.tsx
@@ -20,78 +20,68 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import * as React from "react"
+import "./index.css"
 
-import * as React from 'react';
-import './index.css';
-import {
-    widget,
-    ChartingLibraryWidgetOptions,
-    LanguageCode,
-    IChartingLibraryWidget,
-    ResolutionString,
-} from '../../charting_library';
+const widget = (window as any)?.TradingView.widget
 
 export interface ChartContainerProps {
-    symbol: ChartingLibraryWidgetOptions['symbol'];
-    interval: ChartingLibraryWidgetOptions['interval'];
+    symbol: string
+    interval: string
 
-    // BEWARE: no trailing slash is expected in feed URL
-    datafeedUrl: string;
-    libraryPath: ChartingLibraryWidgetOptions['library_path'];
-    chartsStorageUrl: ChartingLibraryWidgetOptions['charts_storage_url'];
-    chartsStorageApiVersion: ChartingLibraryWidgetOptions['charts_storage_api_version'];
-    clientId: ChartingLibraryWidgetOptions['client_id'];
-    userId: ChartingLibraryWidgetOptions['user_id'];
-    fullscreen: ChartingLibraryWidgetOptions['fullscreen'];
-    autosize: ChartingLibraryWidgetOptions['autosize'];
-    studiesOverrides: ChartingLibraryWidgetOptions['studies_overrides'];
-    container: ChartingLibraryWidgetOptions['container'];
+    datafeed: any
+    libraryPath: string
+    chartsStorageUrl: string
+    chartsStorageApiVersion: string
+    clientId: string
+    userId: string
+    fullscreen: boolean
+    autosize: boolean
+    studiesOverrides: any
+    container: any
 }
 
-export interface ChartContainerState {
-}
+export interface ChartContainerState {}
 
-function getLanguageFromURL(): LanguageCode | null {
-    const regex = new RegExp('[\\?&]lang=([^&#]*)');
-    const results = regex.exec(location.search);
-    return results === null ? null : decodeURIComponent(results[1].replace(/\+/g, ' ')) as LanguageCode;
+function getLanguageFromURL(): string | null {
+    const regex = new RegExp("[\\?&]lang=([^&#]*)")
+    const results = regex.exec(window.location.search)
+    return results === null ? null : decodeURIComponent(results[1].replace(/\+/g, " "))
 }
 
 export class TVChartContainer extends React.PureComponent<Partial<ChartContainerProps>, ChartContainerState> {
-    public static defaultProps: Omit<ChartContainerProps, 'container'> = {
-        symbol: 'AAPL',
-        interval: 'D' as ResolutionString,
-        datafeedUrl: 'https://demo_feed.tradingview.com',
-        libraryPath: '/charting_library/',
-        chartsStorageUrl: 'https://saveload.tradingview.com',
-        chartsStorageApiVersion: '1.1',
-        clientId: 'tradingview.com',
-        userId: 'public_user_id',
+    public static defaultProps: Omit<ChartContainerProps, "container"> = {
+        symbol: "AAPL",
+        interval: "D",
+        datafeed: {},
+        libraryPath: "/charting_library/",
+        chartsStorageUrl: "https://saveload.tradingview.com",
+        chartsStorageApiVersion: "1.1",
+        clientId: "tradingview.com",
+        userId: "public_user_id",
         fullscreen: false,
         autosize: true,
         studiesOverrides: {},
-    };
+    }
 
-    private tvWidget: IChartingLibraryWidget | null = null;
-    private ref: React.RefObject<HTMLDivElement> = React.createRef();
+    private tvWidget: any | null = null
+    private ref: React.RefObject<HTMLDivElement> = React.createRef()
 
     public componentDidMount(): void {
         if (!this.ref.current) {
-            return;
+            return
         }
 
-        const widgetOptions: ChartingLibraryWidgetOptions = {
+        const widgetOptions = {
             symbol: this.props.symbol as string,
-            // BEWARE: no trailing slash is expected in feed URL
-            // tslint:disable-next-line:no-any
-            datafeed: new (window as any).Datafeeds.UDFCompatibleDatafeed(this.props.datafeedUrl),
-            interval: this.props.interval as ChartingLibraryWidgetOptions['interval'],
+            datafeed: this.props.datafeed,
+            interval: this.props.interval,
             container: this.ref.current,
             library_path: this.props.libraryPath as string,
 
-            locale: getLanguageFromURL() || 'en',
-            disabled_features: ['use_localstorage_for_settings'],
-            enabled_features: ['study_templates'],
+            locale: getLanguageFromURL() || "en",
+            disabled_features: ["use_localstorage_for_settings"],
+            enabled_features: ["study_templates"],
             charts_storage_url: this.props.chartsStorageUrl,
             charts_storage_api_version: this.props.chartsStorageApiVersion,
             client_id: this.props.clientId,
@@ -99,41 +89,40 @@ export class TVChartContainer extends React.PureComponent<Partial<ChartContainer
             fullscreen: this.props.fullscreen,
             autosize: this.props.autosize,
             studies_overrides: this.props.studiesOverrides,
-        };
 
-        const tvWidget = new widget(widgetOptions);
-        this.tvWidget = tvWidget;
+            theme: "dark",
+        }
+
+        const tvWidget = new widget(widgetOptions)
+        this.tvWidget = tvWidget
 
         tvWidget.onChartReady(() => {
             tvWidget.headerReady().then(() => {
-                const button = tvWidget.createButton();
-                button.setAttribute('title', 'Click to show a notification popup');
-                button.classList.add('apply-common-tooltip');
-                button.addEventListener('click', () => tvWidget.showNoticeDialog({
-                    title: 'Notification',
-                    body: 'TradingView Charting Library API works correctly',
-                    callback: () => {
-                        console.log('Noticed!');
-                    },
-                }));
-                button.innerHTML = 'Check API';
-            });
-        });
+                const button = tvWidget.createButton()
+                button.setAttribute("title", "Click to show a notification popup")
+                button.classList.add("apply-common-tooltip")
+                button.addEventListener("click", () =>
+                    tvWidget.showNoticeDialog({
+                        title: "Notification",
+                        body: "TradingView Charting Library API works correctly",
+                        callback: () => {
+                            console.log("Noticed!")
+                        },
+                    }),
+                )
+                button.innerHTML = "Check API"
+            })
+        })
     }
 
     public componentWillUnmount(): void {
         if (this.tvWidget !== null) {
-            this.tvWidget.remove();
-            this.tvWidget = null;
+            this.tvWidget.remove()
+            this.tvWidget = null
         }
     }
 
     public render(): JSX.Element {
-        return (
-            <div
-                ref={ this.ref }
-        className={ 'TVChartContainer' }
-        />
-    );
+        return <div ref={this.ref} className={"TVChartContainer"} />
     }
 }

--- a/src/tradingView/TVChartContainer.tsx
+++ b/src/tradingView/TVChartContainer.tsx
@@ -51,7 +51,7 @@ export const TVChartContainer = (props: ChartContainerProps) => {
 
     const defaultProps: Omit<ChartContainerProps, "container"> = {
         symbol: "AAPL",
-        interval: "D",
+        interval: "5",
         datafeed: {},
         libraryPath: "/charting_library/",
         chartsStorageUrl: "https://saveload.tradingview.com",

--- a/src/tradingView/TVChartContainer.tsx
+++ b/src/tradingView/TVChartContainer.tsx
@@ -1,0 +1,139 @@
+// MIT License
+//
+// Copyright (c) 2018 TradingView, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+import * as React from 'react';
+import './index.css';
+import {
+    widget,
+    ChartingLibraryWidgetOptions,
+    LanguageCode,
+    IChartingLibraryWidget,
+    ResolutionString,
+} from '../../charting_library';
+
+export interface ChartContainerProps {
+    symbol: ChartingLibraryWidgetOptions['symbol'];
+    interval: ChartingLibraryWidgetOptions['interval'];
+
+    // BEWARE: no trailing slash is expected in feed URL
+    datafeedUrl: string;
+    libraryPath: ChartingLibraryWidgetOptions['library_path'];
+    chartsStorageUrl: ChartingLibraryWidgetOptions['charts_storage_url'];
+    chartsStorageApiVersion: ChartingLibraryWidgetOptions['charts_storage_api_version'];
+    clientId: ChartingLibraryWidgetOptions['client_id'];
+    userId: ChartingLibraryWidgetOptions['user_id'];
+    fullscreen: ChartingLibraryWidgetOptions['fullscreen'];
+    autosize: ChartingLibraryWidgetOptions['autosize'];
+    studiesOverrides: ChartingLibraryWidgetOptions['studies_overrides'];
+    container: ChartingLibraryWidgetOptions['container'];
+}
+
+export interface ChartContainerState {
+}
+
+function getLanguageFromURL(): LanguageCode | null {
+    const regex = new RegExp('[\\?&]lang=([^&#]*)');
+    const results = regex.exec(location.search);
+    return results === null ? null : decodeURIComponent(results[1].replace(/\+/g, ' ')) as LanguageCode;
+}
+
+export class TVChartContainer extends React.PureComponent<Partial<ChartContainerProps>, ChartContainerState> {
+    public static defaultProps: Omit<ChartContainerProps, 'container'> = {
+        symbol: 'AAPL',
+        interval: 'D' as ResolutionString,
+        datafeedUrl: 'https://demo_feed.tradingview.com',
+        libraryPath: '/charting_library/',
+        chartsStorageUrl: 'https://saveload.tradingview.com',
+        chartsStorageApiVersion: '1.1',
+        clientId: 'tradingview.com',
+        userId: 'public_user_id',
+        fullscreen: false,
+        autosize: true,
+        studiesOverrides: {},
+    };
+
+    private tvWidget: IChartingLibraryWidget | null = null;
+    private ref: React.RefObject<HTMLDivElement> = React.createRef();
+
+    public componentDidMount(): void {
+        if (!this.ref.current) {
+            return;
+        }
+
+        const widgetOptions: ChartingLibraryWidgetOptions = {
+            symbol: this.props.symbol as string,
+            // BEWARE: no trailing slash is expected in feed URL
+            // tslint:disable-next-line:no-any
+            datafeed: new (window as any).Datafeeds.UDFCompatibleDatafeed(this.props.datafeedUrl),
+            interval: this.props.interval as ChartingLibraryWidgetOptions['interval'],
+            container: this.ref.current,
+            library_path: this.props.libraryPath as string,
+
+            locale: getLanguageFromURL() || 'en',
+            disabled_features: ['use_localstorage_for_settings'],
+            enabled_features: ['study_templates'],
+            charts_storage_url: this.props.chartsStorageUrl,
+            charts_storage_api_version: this.props.chartsStorageApiVersion,
+            client_id: this.props.clientId,
+            user_id: this.props.userId,
+            fullscreen: this.props.fullscreen,
+            autosize: this.props.autosize,
+            studies_overrides: this.props.studiesOverrides,
+        };
+
+        const tvWidget = new widget(widgetOptions);
+        this.tvWidget = tvWidget;
+
+        tvWidget.onChartReady(() => {
+            tvWidget.headerReady().then(() => {
+                const button = tvWidget.createButton();
+                button.setAttribute('title', 'Click to show a notification popup');
+                button.classList.add('apply-common-tooltip');
+                button.addEventListener('click', () => tvWidget.showNoticeDialog({
+                    title: 'Notification',
+                    body: 'TradingView Charting Library API works correctly',
+                    callback: () => {
+                        console.log('Noticed!');
+                    },
+                }));
+                button.innerHTML = 'Check API';
+            });
+        });
+    }
+
+    public componentWillUnmount(): void {
+        if (this.tvWidget !== null) {
+            this.tvWidget.remove();
+            this.tvWidget = null;
+        }
+    }
+
+    public render(): JSX.Element {
+        return (
+            <div
+                ref={ this.ref }
+        className={ 'TVChartContainer' }
+        />
+    );
+    }
+}

--- a/src/tradingView/datafeed.ts
+++ b/src/tradingView/datafeed.ts
@@ -1,0 +1,159 @@
+import { MarketState } from "../constant/types"
+import { createMarketContract } from "../container/connection/contractFactory"
+import _ from "lodash"
+import { bigNum2Big, x96ToNumber } from "../util/format"
+
+interface DataFeedConfig {
+    signer: any
+    marketState: MarketState
+}
+
+const configurationData = {
+    exchanges: [
+        {
+            value: "perpdex",
+            name: "PerpDEX",
+            desc: "PerpDEX",
+        },
+    ],
+    symbols_types: [
+        {
+            name: "crypto",
+            value: "crypto",
+        },
+    ],
+    supported_resolutions: ["1", "5", "60", "240", "1D"],
+}
+
+export const createDataFeed = (config: DataFeedConfig) => {
+    const { marketState } = config
+    const contract = createMarketContract(config.marketState.address, config.signer)
+    const inverse = marketState.inverse
+    let subscriptions: any[] = []
+
+    return {
+        onReady: (callback: any) => {
+            console.log("data feed onReady called")
+            callback(configurationData)
+        },
+        searchSymbols: (userInput: string, exchange: string, symbolType: string, onResultReadyCallback: any) => {
+            const result = [
+                {
+                    symbol: marketState.name,
+                    full_name: marketState.name,
+                    description: marketState.name,
+                    exchange: "perpdex",
+                    ticker: marketState.name,
+                    type: "crypto",
+                },
+            ]
+            onResultReadyCallback(result)
+        },
+        resolveSymbol: async (symbolName: string, onSymbolResolvedCallback: any, onResolveErrorCallback: any) => {
+            console.log("data feed resolveSymbol called", symbolName)
+
+            const symbolInfo = {
+                ticker: symbolName,
+                name: symbolName,
+                description: symbolName,
+                type: "crypto",
+                session: "24x7",
+                timezone: "Etc/UTC", // TODO: should change?
+                exchange: "perpdex",
+                minmov: 1,
+                pricescale: 100,
+                has_intraday: true,
+                has_no_volume: false,
+                has_weekly_and_monthly: false,
+                supported_resolutions: configurationData.supported_resolutions,
+                volume_precision: 2,
+                data_status: "streaming",
+            }
+
+            onSymbolResolvedCallback(symbolInfo)
+        },
+        getBars: async (
+            symbolInfo: any,
+            resolution: string,
+            periodParams: any,
+            onHistoryCallback: any,
+            onErrorCallback: any,
+        ) => {
+            const { from, to, firstDataRequest } = periodParams
+            console.log("data feed getBars called", symbolInfo, resolution, from, to)
+
+            const interval =
+                {
+                    "1D": 24 * 60 * 60,
+                }[resolution] || +resolution * 60
+
+            try {
+                // TODO: chunk
+                let from2 = Math.max(0, Math.floor(from / interval) * interval)
+                const to2 = Math.max(0, Math.floor(to / interval) * interval)
+
+                let bars: any[] = []
+                while (from2 < to2) {
+                    const step = Math.min(200, (to2 - from2) / interval)
+                    const candles = await contract.getCandles(interval, from2, step)
+                    bars.push(
+                        _.map(candles, (candle, idx: number) => {
+                            return {
+                                time: (from2 + idx * interval) * 1000,
+                                low: x96ToNumber(candle.lowX96, inverse),
+                                high: x96ToNumber(candle.highX96, inverse),
+                                close: x96ToNumber(candle.closeX96, inverse),
+                                open: 0,
+                                volume: bigNum2Big(candle.quote).toNumber(),
+                            }
+                        }),
+                    )
+                    from2 += step * interval
+                }
+                bars = _.flatten(bars)
+                console.log("data feed", bars)
+
+                bars = _.filter(bars, candle => {
+                    return candle.close !== 0
+                })
+                _.each(bars, (bar, idx: number) => {
+                    bar.open = bars[idx === 0 ? 0 : idx - 1].close
+                })
+
+                console.log(`data feed getBars returned ${bars.length} bars`)
+                onHistoryCallback(bars, { noData: _.isEmpty(bars) })
+            } catch (error) {
+                console.log("data feed getBars error", error)
+                onErrorCallback(error)
+            }
+        },
+        subscribeBars(
+            symbolInfo: any,
+            resolution: any,
+            onRealtimeCallback: any,
+            subscriberUID: any,
+            onResetCacheNeededCallback: any,
+        ) {
+            console.log("data feed subscribeBars", symbolInfo, resolution, subscriberUID)
+            const timerId = setInterval(async () => {
+                // TODO:
+            }, 60 * 1000)
+            subscriptions.push({
+                timerId: timerId,
+                subscriberUID: subscriberUID,
+            })
+        },
+        unsubscribeBars(subscriberUID: any) {
+            console.log("data feed unsubscribeBars", subscriberUID)
+            const subscription = _.find(subscriptions, subscription => {
+                return subscription.subscriberUID === subscriberUID
+            })
+            if (!subscription) return
+
+            clearInterval(subscription.timerId)
+            subscriptions = _.filter(subscriptions, subscription => {
+                return subscription.subscriberUID !== subscriberUID
+            })
+        },
+    }
+}

--- a/src/tradingView/index.css
+++ b/src/tradingView/index.css
@@ -1,0 +1,4 @@
+.TVChartContainer {
+    height: 100%;
+    width: 100%;
+}


### PR DESCRIPTION
changes

- optionally build with charting library depending on CHARTING_LIBRARY_PATH env var
- build with charting library in github actions

changes related to perpdex/perpdex-tradingview
- switch react component for chart depending on window.TradingView existence
- create react component for charting library
  - inject window.TradingView (and other required tv dependencies) to avoid depending on how the charting library is loaded
=> use REACT_APP_ENABLE_TRADING_VIEW_TECHNICAL=true in .env when using 
- perpdex/perpdex-tradingview
  - this can be public repository because proprietry charting-library is not included and injected.
  - this should be renamed because this repository shouldn’t depend on perpdex. this repository should be designed as general react wrapper for charting-library.
  - If the amount of code is small, it may be more efficient to include it in perpdex-lite instead of separating it in a separate repository
=> removed dependencies of perpdex/perpdex-tradingview, and integrated as TradingViewComponent 

fork candidates
  -  https://github.com/Kaktana/kaktana-react-lightweight-charts/blob/master/src/kaktana-react-lightweight-charts.js
  - https://github.com/tradingview/charting-library-examples/blob/master/react-typescript/src/components/TVChartContainer/index.tsx (selected)
  - https://github.com/project-serum/serum-dex-ui/blob/master/src/components/TradingView/index.tsx
  - https://github.com/raydium-io/raydium-dex/blob/master/src/components/TradingView/index.tsx

reference: https://github.com/perpdex/perpdex-lite/pull/95
