### PR TITLE
notify when failed to connect to unsupported networks

### DIFF
--- a/src/container/connection/user.tsx
+++ b/src/container/connection/user.tsx
@@ -75,9 +75,13 @@ function useUser() {
                     setConnectorId("")
                     dispatch({ type: ACTIONS.LOGIN_FAIL })
                     logger.error(err)
+                    notifyError({
+                        title: "Switch a supported network in Metamask to connect",
+                        position: "top-right",
+                    })
                 })
         },
-        [dispatch, setConnectorId, activate],
+        [dispatch, setConnectorId, activate, notifyError],
     )
 
     const logout = useCallback(() => {


### PR DESCRIPTION
changes
- show the message through toast when failed to connect to unsupported networks

<img width="696" alt="image" src="https://user-images.githubusercontent.com/20024675/184771166-3af0e4e7-b9a2-4395-b813-bc66305e0eeb.png">
