### PR TITLE
Fix 100 percent position close

### DIFF
--- a/src/component/base/DiscreteInputModifier/index.tsx
+++ b/src/component/base/DiscreteInputModifier/index.tsx
@@ -61,8 +61,9 @@ function DiscreteInputModifier({
 
     const handleDiscreteUpdate = useCallback(
         (percent: number) => {
+            // Rounding when dividing
             const nextValue = maxValue.mul(percent).div(100)
-            setInputValue(nextValue.toFixed(6))
+            setInputValue(nextValue.toFixed(7))
             handleUpdate(nextValue)
         },
         [handleUpdate, maxValue],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,12 +26,15 @@ import theme from "./theme"
 import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client"
 import { networkConfigs } from "./constant/network"
 import _ from "lodash"
+import Big from "big.js"
 
 declare global {
     interface Window {
         ethereum: any
     }
 }
+
+Big.DP = 100
 
 // NOTE: third party services
 setupSegment()


### PR DESCRIPTION
changes
 - Set the number of decimal places to a maximum of 100 because the default digit of 20 is used when dividing and rounding occurs.
 - Match the number of digits displayed with the position tab.