### PR TITLE
Fix leaderboard pagination bugs / Updated histories table 

### DIFF
--- a/src/component/tables/histories/getColumns.ts
+++ b/src/component/tables/histories/getColumns.ts
@@ -1,0 +1,54 @@
+export function getDepositedColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        {
+            Header: "Deposit Amount",
+            accessor: "amount",
+        },
+    ]
+}
+
+export function getWithdrawnColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        {
+            Header: "Withdrawn Amount",
+            accessor: "amount",
+        },
+    ]
+}
+
+export function getLiquidityAddedExchangeColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        // {
+        //     Header: "Market",
+        //     accessor: "market",
+        // },
+        {
+            Header: "Liquidity",
+            accessor: "liquidity",
+        },
+    ]
+}

--- a/src/component/tables/histories/getColumns.ts
+++ b/src/component/tables/histories/getColumns.ts
@@ -52,3 +52,32 @@ export function getLiquidityAddedExchangeColumn() {
         },
     ]
 }
+
+export function getLiquidityRemovedExchangeColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        // {
+        //     Header: "Market",
+        //     accessor: "market",
+        // },
+        {
+            Header: "Liquidator",
+            accessor: "liquidator",
+        },
+        {
+            Header: "Liquidity",
+            accessor: "liquidity",
+        },
+        {
+            Header: "Realized PNL",
+            accessor: "realizedPnl",
+        },
+    ]
+}

--- a/src/component/tables/histories/getColumns.ts
+++ b/src/component/tables/histories/getColumns.ts
@@ -81,3 +81,28 @@ export function getLiquidityRemovedExchangeColumn() {
         },
     ]
 }
+
+export function getPositionChangedColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        // {
+        //     Header: "Market",
+        //     accessor: "market",
+        // },
+        {
+            Header: "Realized PNL",
+            accessor: "realizedPnl",
+        },
+        {
+            Header: "Protocol Fee",
+            accessor: "protocolFee",
+        },
+    ]
+}

--- a/src/component/tables/histories/getColumns.ts
+++ b/src/component/tables/histories/getColumns.ts
@@ -139,3 +139,40 @@ export function getOrderColumn() {
         // },
     ]
 }
+
+export function getLimitOrderCreatedExchangeColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        // {
+        //     Header: "Market",
+        //     accessor: "market",
+        // },
+        {
+            Header: "Bid/Ask",
+            accessor: "bidOrAsk",
+        },
+        {
+            Header: "Order id",
+            accessor: "orderId",
+        },
+        {
+            Header: "Price",
+            accessor: "price",
+        },
+        {
+            Header: "Base",
+            accessor: "base",
+        },
+        // {
+        //     Header: "Limit Order Type",
+        //     accessor: "limitOrderType",
+        // },
+    ]
+}

--- a/src/component/tables/histories/getColumns.ts
+++ b/src/component/tables/histories/getColumns.ts
@@ -176,3 +176,32 @@ export function getLimitOrderCreatedExchangeColumn() {
         // },
     ]
 }
+
+export function getLimitOrderSettledColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        // {
+        //     Header: "Market",
+        //     accessor: "market",
+        // },
+        // {
+        //     Header: "Base",
+        //     accessor: "base",
+        // },
+        // {
+        //     Header: "Quote",
+        //     accessor: "quote",
+        // },
+        {
+            Header: "Realized PNL",
+            accessor: "realizedPnl",
+        },
+    ]
+}

--- a/src/component/tables/histories/getColumns.ts
+++ b/src/component/tables/histories/getColumns.ts
@@ -106,3 +106,36 @@ export function getPositionChangedColumn() {
         },
     ]
 }
+
+export function getOrderColumn() {
+    return [
+        {
+            Header: "Time",
+            accessor: "time",
+        },
+        {
+            Header: "Trader",
+            accessor: "trader",
+        },
+        // {
+        //     Header: "Market",
+        //     accessor: "market",
+        // },
+        {
+            Header: "Order id",
+            accessor: "orderId",
+        },
+        {
+            Header: "Price",
+            accessor: "price",
+        },
+        {
+            Header: "Volume",
+            accessor: "volume",
+        },
+        // {
+        //     Header: "Limit Order Type",
+        //     accessor: "limitOrderType",
+        // },
+    ]
+}

--- a/src/component/tables/histories/index.tsx
+++ b/src/component/tables/histories/index.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react"
 import { HistoryColumn, HistoryDataType } from "constant/types"
 import {
     getDepositedsQuery,
+    getLimitOrderCreatedExchangesQuery,
     getLiquidityAddedExchangesQuery,
     getLiquidityRemovedExchangesQuery,
     getOrdersQuery,
@@ -10,6 +11,7 @@ import {
 import { useThegraphQuery } from "hook/useThegraphQuery"
 import {
     cleanUpDepositeds,
+    cleanUpLimitOrderCreatedExchanges,
     cleanUpLiquidityAddedExchanges,
     cleanUpLiquidityRemovedExchanges,
     cleanUpOrders,
@@ -21,6 +23,7 @@ import { Connection } from "container/connection"
 import HistoriesTableWrapper from "./HistoriesTableWrapper"
 import {
     getDepositedColumn,
+    getLimitOrderCreatedExchangeColumn,
     getLiquidityAddedExchangeColumn,
     getLiquidityRemovedExchangeColumn,
     getOrderColumn,
@@ -66,6 +69,12 @@ const historyMethodsMap = {
         doMarketFilter: true,
         cleanUpMethod: cleanUpOrders,
         getColumn: getOrderColumn,
+    },
+    LimitOrderCreatedExchanges: {
+        query: getLimitOrderCreatedExchangesQuery,
+        doMarketFilter: true,
+        cleanUpMethod: cleanUpLimitOrderCreatedExchanges,
+        getColumn: getLimitOrderCreatedExchangeColumn,
     },
 }
 

--- a/src/component/tables/histories/index.tsx
+++ b/src/component/tables/histories/index.tsx
@@ -110,10 +110,7 @@ function HistoriesTable({ historyDataType }: Props) {
     const data = useMemo(() => {
         if (results.error) console.error("query error: ", results.error)
         if (results.loading || results.error || !cleanUpMethod) return []
-        console.log("@@@@ histories query data", results.data)
         const allData = cleanUpMethod(results.data)
-
-        console.log("@@@@ histories clean allData", allData)
 
         return allData as any[]
     }, [cleanUpMethod, results.data, results.error, results.loading])

--- a/src/component/tables/histories/index.tsx
+++ b/src/component/tables/histories/index.tsx
@@ -1,12 +1,27 @@
 import { useMemo } from "react"
 import { HistoryColumn, HistoryDataType } from "constant/types"
-import { getDepositedsQuery, getLiquidityAddedExchangesQuery, getWithdrawnsQuery } from "queries/account"
+import {
+    getDepositedsQuery,
+    getLiquidityAddedExchangesQuery,
+    getLiquidityRemovedExchangesQuery,
+    getWithdrawnsQuery,
+} from "queries/account"
 import { useThegraphQuery } from "hook/useThegraphQuery"
-import { cleanUpDepositeds, cleanUpLiquidityAddedExchanges, cleanUpWithdrawn } from "util/queries"
+import {
+    cleanUpDepositeds,
+    cleanUpLiquidityAddedExchanges,
+    cleanUpLiquidityRemovedExchanges,
+    cleanUpWithdrawn,
+} from "util/queries"
 import { Column } from "react-table"
 import { Connection } from "container/connection"
 import HistoriesTableWrapper from "./HistoriesTableWrapper"
-import { getDepositedColumn, getLiquidityAddedExchangeColumn, getWithdrawnColumn } from "./getColumns"
+import {
+    getDepositedColumn,
+    getLiquidityAddedExchangeColumn,
+    getLiquidityRemovedExchangeColumn,
+    getWithdrawnColumn,
+} from "./getColumns"
 
 const historyMethodsMap = {
     Deposited: {
@@ -23,6 +38,11 @@ const historyMethodsMap = {
         query: getLiquidityAddedExchangesQuery,
         cleanUpMethod: cleanUpLiquidityAddedExchanges,
         getColumn: getLiquidityAddedExchangeColumn,
+    },
+    LiquidityRemovedExchanges: {
+        query: getLiquidityRemovedExchangesQuery,
+        cleanUpMethod: cleanUpLiquidityRemovedExchanges,
+        getColumn: getLiquidityRemovedExchangeColumn,
     },
 }
 

--- a/src/component/tables/histories/index.tsx
+++ b/src/component/tables/histories/index.tsx
@@ -8,11 +8,11 @@ import { Connection } from "container/connection"
 import HistoriesTableWrapper from "./HistoriesTableWrapper"
 
 function getMethodsByHistoryDataType(type: HistoryDataType) {
-    const query = type === "deposited" ? getDepositedsQuery : undefined
+    const query = type === "Deposited" ? getDepositedsQuery : undefined
 
-    const cleanUpMethod = type === "deposited" ? cleanUpDepositeds : undefined
+    const cleanUpMethod = type === "Deposited" ? cleanUpDepositeds : undefined
 
-    const getColumn = type === "deposited" ? getDepositedColumn : getDepositedColumn
+    const getColumn = type === "Deposited" ? getDepositedColumn : getDepositedColumn
 
     return {
         query,

--- a/src/component/tables/histories/index.tsx
+++ b/src/component/tables/histories/index.tsx
@@ -4,13 +4,15 @@ import {
     getDepositedsQuery,
     getLiquidityAddedExchangesQuery,
     getLiquidityRemovedExchangesQuery,
+    getOrdersQuery,
     getWithdrawnsQuery,
-} from "queries/account"
+} from "queries/histories"
 import { useThegraphQuery } from "hook/useThegraphQuery"
 import {
     cleanUpDepositeds,
     cleanUpLiquidityAddedExchanges,
     cleanUpLiquidityRemovedExchanges,
+    cleanUpOrders,
     cleanUpPositionChangeds,
     cleanUpWithdrawn,
 } from "util/queries"
@@ -21,6 +23,7 @@ import {
     getDepositedColumn,
     getLiquidityAddedExchangeColumn,
     getLiquidityRemovedExchangeColumn,
+    getOrderColumn,
     getPositionChangedColumn,
     getWithdrawnColumn,
 } from "./getColumns"
@@ -57,6 +60,12 @@ const historyMethodsMap = {
         doMarketFilter: true,
         cleanUpMethod: cleanUpPositionChangeds,
         getColumn: getPositionChangedColumn,
+    },
+    Orders: {
+        query: getOrdersQuery,
+        doMarketFilter: true,
+        cleanUpMethod: cleanUpOrders,
+        getColumn: getOrderColumn,
     },
 }
 

--- a/src/component/tables/histories/index.tsx
+++ b/src/component/tables/histories/index.tsx
@@ -3,6 +3,7 @@ import { HistoryColumn, HistoryDataType } from "constant/types"
 import {
     getDepositedsQuery,
     getLimitOrderCreatedExchangesQuery,
+    getLimitOrderSettledsQuery,
     getLiquidityAddedExchangesQuery,
     getLiquidityRemovedExchangesQuery,
     getOrdersQuery,
@@ -12,6 +13,7 @@ import { useThegraphQuery } from "hook/useThegraphQuery"
 import {
     cleanUpDepositeds,
     cleanUpLimitOrderCreatedExchanges,
+    cleanUpLimitOrderSettleds,
     cleanUpLiquidityAddedExchanges,
     cleanUpLiquidityRemovedExchanges,
     cleanUpOrders,
@@ -24,6 +26,7 @@ import HistoriesTableWrapper from "./HistoriesTableWrapper"
 import {
     getDepositedColumn,
     getLimitOrderCreatedExchangeColumn,
+    getLimitOrderSettledColumn,
     getLiquidityAddedExchangeColumn,
     getLiquidityRemovedExchangeColumn,
     getOrderColumn,
@@ -75,6 +78,12 @@ const historyMethodsMap = {
         doMarketFilter: true,
         cleanUpMethod: cleanUpLimitOrderCreatedExchanges,
         getColumn: getLimitOrderCreatedExchangeColumn,
+    },
+    LimitOrderSettleds: {
+        query: getLimitOrderSettledsQuery,
+        doMarketFilter: true,
+        cleanUpMethod: cleanUpLimitOrderSettleds,
+        getColumn: getLimitOrderSettledColumn,
     },
 }
 

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -170,7 +170,7 @@ export interface Withdrawns {
 
 export type HistoryColumn = Deposited | Withdrawns
 
-export type HistoryDataType = "Deposited" | "Withdrawn" | "LiquidityAddedExchanges"
+export type HistoryDataType = "Deposited" | "Withdrawn" | "LiquidityAddedExchanges" | "LiquidityRemovedExchanges"
 
 export interface HistoryData {
     title: string

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -170,7 +170,7 @@ export interface Withdrawns {
 
 export type HistoryColumn = Deposited | Withdrawns
 
-export type HistoryDataType = "Deposited" | "Withdrawn"
+export type HistoryDataType = "Deposited" | "Withdrawn" | "LiquidityAddedExchanges"
 
 export interface HistoryData {
     title: string

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -178,6 +178,7 @@ export type HistoryDataType =
     | "PositionChangeds"
     | "Orders"
     | "LimitOrderCreatedExchanges"
+    | "LimitOrderSettleds"
 
 export interface HistoryData {
     title: string

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -176,6 +176,7 @@ export type HistoryDataType =
     | "LiquidityAddedExchanges"
     | "LiquidityRemovedExchanges"
     | "PositionChangeds"
+    | "Orders"
 
 export interface HistoryData {
     title: string

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -177,6 +177,7 @@ export type HistoryDataType =
     | "LiquidityRemovedExchanges"
     | "PositionChangeds"
     | "Orders"
+    | "LimitOrderCreatedExchanges"
 
 export interface HistoryData {
     title: string

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -170,7 +170,12 @@ export interface Withdrawns {
 
 export type HistoryColumn = Deposited | Withdrawns
 
-export type HistoryDataType = "Deposited" | "Withdrawn" | "LiquidityAddedExchanges" | "LiquidityRemovedExchanges"
+export type HistoryDataType =
+    | "Deposited"
+    | "Withdrawn"
+    | "LiquidityAddedExchanges"
+    | "LiquidityRemovedExchanges"
+    | "PositionChangeds"
 
 export interface HistoryData {
     title: string

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -156,15 +156,21 @@ export interface LeaderboardScoreUnit {
     deposit: string
 }
 
-export interface Depositeds {
+export interface Deposited {
     time: string
     trader: string
     amount: string
 }
 
-export type HistoryColumn = Depositeds
+export interface Withdrawns {
+    time: string
+    trader: string
+    amount: string
+}
 
-export type HistoryDataType = "deposited"
+export type HistoryColumn = Deposited | Withdrawns
+
+export type HistoryDataType = "Deposited" | "Withdrawn"
 
 export interface HistoryData {
     title: string

--- a/src/page/Histories/DataTabs.tsx
+++ b/src/page/Histories/DataTabs.tsx
@@ -35,6 +35,10 @@ function DataTabs() {
             title: "Orders",
             type: "Orders",
         },
+        {
+            title: "Limit Order Created",
+            type: "LimitOrderCreatedExchanges",
+        },
     ]
 
     return (

--- a/src/page/Histories/DataTabs.tsx
+++ b/src/page/Histories/DataTabs.tsx
@@ -27,6 +27,10 @@ function DataTabs() {
             title: "Liquidity Removed",
             type: "LiquidityRemovedExchanges",
         },
+        {
+            title: "Position Changed",
+            type: "PositionChangeds",
+        },
     ]
 
     return (

--- a/src/page/Histories/DataTabs.tsx
+++ b/src/page/Histories/DataTabs.tsx
@@ -23,6 +23,10 @@ function DataTabs() {
             title: "Liquidity Added",
             type: "LiquidityAddedExchanges",
         },
+        {
+            title: "Liquidity Removed",
+            type: "LiquidityRemovedExchanges",
+        },
     ]
 
     return (

--- a/src/page/Histories/DataTabs.tsx
+++ b/src/page/Histories/DataTabs.tsx
@@ -1,0 +1,47 @@
+import { TabPanels, TabPanel, Tabs, TabList, Divider, chakra, Tab } from "@chakra-ui/react"
+import HistoriesTable from "component/tables/histories"
+import { HistoryData } from "constant/types"
+
+function DataTabs() {
+    const StyledTab = chakra(Tab, {
+        baseStyle: {
+            color: "gray.200",
+            _selected: { color: "white", borderBottom: "1px solid #627EEA" },
+        },
+    })
+
+    const dataTypes: HistoryData[] = [
+        {
+            title: "Deposit",
+            type: "Deposited",
+        },
+        {
+            title: "Withdrawn",
+            type: "Withdrawn",
+        },
+        {
+            title: "Liquidity Added",
+            type: "LiquidityAddedExchanges",
+        },
+    ]
+
+    return (
+        <Tabs isManual isLazy>
+            <TabList>
+                {dataTypes.map((data: HistoryData, index) => (
+                    <StyledTab key={index}>{data.title}</StyledTab>
+                ))}
+            </TabList>
+            <Divider borderColor="#627EEA" />
+            <TabPanels>
+                {dataTypes.map((data, index) => (
+                    <TabPanel key={index} paddingX={0}>
+                        <HistoriesTable historyDataType={data.type} />
+                    </TabPanel>
+                ))}
+            </TabPanels>
+        </Tabs>
+    )
+}
+
+export default DataTabs

--- a/src/page/Histories/DataTabs.tsx
+++ b/src/page/Histories/DataTabs.tsx
@@ -39,6 +39,10 @@ function DataTabs() {
             title: "Limit Order Created",
             type: "LimitOrderCreatedExchanges",
         },
+        {
+            title: "Limit Order Settleds",
+            type: "LimitOrderSettleds",
+        },
     ]
 
     return (

--- a/src/page/Histories/DataTabs.tsx
+++ b/src/page/Histories/DataTabs.tsx
@@ -31,6 +31,10 @@ function DataTabs() {
             title: "Position Changed",
             type: "PositionChangeds",
         },
+        {
+            title: "Orders",
+            type: "Orders",
+        },
     ]
 
     return (

--- a/src/page/Histories/index.tsx
+++ b/src/page/Histories/index.tsx
@@ -1,28 +1,9 @@
-import { VStack, Text, TabPanels, TabPanel, Tabs, TabList, Divider, chakra, Tab } from "@chakra-ui/react"
+import { VStack, Text } from "@chakra-ui/react"
 import { Heading } from "@chakra-ui/react"
 import FrameContainer from "component/frames/FrameContainer"
-import HistoriesTable from "component/tables/histories"
-import { HistoryData } from "constant/types"
+import DataTabs from "./DataTabs"
 
 function Histories() {
-    const StyledTab = chakra(Tab, {
-        baseStyle: {
-            color: "gray.200",
-            _selected: { color: "white", borderBottom: "1px solid #627EEA" },
-        },
-    })
-
-    const dataTypes: HistoryData[] = [
-        {
-            title: "Deposit",
-            type: "Deposited",
-        },
-        {
-            title: "Withdraw",
-            type: "Withdrawn",
-        },
-    ]
-
     return (
         <FrameContainer>
             <VStack w="100%">
@@ -33,21 +14,7 @@ function Histories() {
                     <Text>Latest trading events are queired and displayed as table</Text>
                 </VStack>
 
-                <Tabs>
-                    <TabList>
-                        {dataTypes.map(dataType => (
-                            <StyledTab>{dataType.title}</StyledTab>
-                        ))}
-                    </TabList>
-                    <Divider borderColor="#627EEA" />
-                    <TabPanels>
-                        <TabPanel paddingX={0}>
-                            {dataTypes.map(dataType => (
-                                <HistoriesTable historyDataType={dataType.type} />
-                            ))}
-                        </TabPanel>
-                    </TabPanels>
-                </Tabs>
+                <DataTabs />
             </VStack>
         </FrameContainer>
     )

--- a/src/page/Histories/index.tsx
+++ b/src/page/Histories/index.tsx
@@ -15,7 +15,11 @@ function Histories() {
     const dataTypes: HistoryData[] = [
         {
             title: "Deposit",
-            type: "deposited",
+            type: "Deposited",
+        },
+        {
+            title: "Withdraw",
+            type: "Withdrawn",
         },
     ]
 

--- a/src/page/Leaderboard/index.tsx
+++ b/src/page/Leaderboard/index.tsx
@@ -13,6 +13,7 @@ import { cleanUpProfitRatios } from "util/leaderboard"
 import { AiOutlineReload } from "react-icons/ai"
 import _ from "lodash"
 import { LeaderboardScoreUnit } from "constant/types"
+import { PerpdexMarketContainer } from "container/connection/perpdexMarketContainer"
 
 function Leaderboard() {
     const { chainId, account } = Connection.useContainer()
@@ -21,7 +22,12 @@ function Leaderboard() {
 
     const networkConfig = networkConfigs[chainId || 280] // 280 for zkSync
 
-    const profitRatiosResults = useThegraphQuery(chainId, getProfitRatiosQuery, { fetchPolicy: "network-only" })
+    const { currentMarket } = PerpdexMarketContainer.useContainer()
+
+    const profitRatiosResults = useThegraphQuery(chainId, getProfitRatiosQuery, {
+        fetchPolicy: "network-only",
+        variables: { markets: [currentMarket, currentMarket.toLowerCase()] },
+    })
 
     const data = useMemo(() => {
         if (profitRatiosResults.loading || profitRatiosResults.error) return []

--- a/src/queries/account.ts
+++ b/src/queries/account.ts
@@ -18,3 +18,46 @@ export const getDepositedsQuery = (schemaType: "thegraph" | "subquery") => {
         subquery: undefined,
     }[schemaType]
 }
+
+export const getWithdrawnsQuery = (schemaType: "thegraph" | "subquery") => {
+    return {
+        thegraph: gql`
+            query {
+                withdrawns(first: 100) {
+                    id
+                    exchange
+                    trader
+                    amount
+
+                    blockNumberLogIndex
+                    timestamp
+                }
+            }
+        `,
+        subquery: undefined,
+    }[schemaType]
+}
+
+export const getLiquidityAddedExchangesQuery = (schemaType: "thegraph" | "subquery") => {
+    return {
+        thegraph: gql`
+            query {
+                liquidityAddedExchanges(first: 100) {
+                    id
+                    exchange
+                    trader
+                    market
+                    base
+                    quote
+                    liquidity
+                    cumBasePerLiquidityX96
+                    cumQuotePerLiquidityX96
+
+                    blockNumberLogIndex
+                    timestamp
+                }
+            }
+        `,
+        subquery: undefined,
+    }[schemaType]
+}

--- a/src/queries/account.ts
+++ b/src/queries/account.ts
@@ -61,3 +61,29 @@ export const getLiquidityAddedExchangesQuery = (schemaType: "thegraph" | "subque
         subquery: undefined,
     }[schemaType]
 }
+
+export const getLiquidityRemovedExchangesQuery = (schemaType: "thegraph" | "subquery") => {
+    return {
+        thegraph: gql`
+            query {
+                liquidityRemovedExchanges(first: 100) {
+                    id
+                    exchange
+                    trader
+                    market
+                    base
+                    quote
+                    liquidity
+                    liquidator
+                    takerBase
+                    takerQuote
+                    realizedPnl
+
+                    blockNumberLogIndex
+                    timestamp
+                }
+            }
+        `,
+        subquery: undefined,
+    }[schemaType]
+}

--- a/src/queries/account.ts
+++ b/src/queries/account.ts
@@ -41,8 +41,13 @@ export const getWithdrawnsQuery = (schemaType: "thegraph" | "subquery") => {
 export const getLiquidityAddedExchangesQuery = (schemaType: "thegraph" | "subquery") => {
     return {
         thegraph: gql`
-            query {
-                liquidityAddedExchanges(first: 100) {
+            query($markets: [String!]) {
+                liquidityAddedExchanges(
+                    first: 100
+                    where: { market_in: $markets }
+                    orderBy: timestamp
+                    orderDirection: desc
+                ) {
                     id
                     exchange
                     trader
@@ -65,8 +70,13 @@ export const getLiquidityAddedExchangesQuery = (schemaType: "thegraph" | "subque
 export const getLiquidityRemovedExchangesQuery = (schemaType: "thegraph" | "subquery") => {
     return {
         thegraph: gql`
-            query {
-                liquidityRemovedExchanges(first: 100) {
+            query($markets: [String!]) {
+                liquidityRemovedExchanges(
+                    first: 100
+                    where: { market_in: $markets }
+                    orderBy: timestamp
+                    orderDirection: desc
+                ) {
                     id
                     exchange
                     trader
@@ -87,3 +97,5 @@ export const getLiquidityRemovedExchangesQuery = (schemaType: "thegraph" | "subq
         subquery: undefined,
     }[schemaType]
 }
+
+// export const getPositionChangedsQuery = (schemaType: "thegraph" | "subquery") => {

--- a/src/queries/histories.ts
+++ b/src/queries/histories.ts
@@ -99,3 +99,25 @@ export const getLiquidityRemovedExchangesQuery = (schemaType: "thegraph" | "subq
 }
 
 // export const getPositionChangedsQuery = (schemaType: "thegraph" | "subquery") => {
+
+export const getOrdersQuery = (schemaType: "thegraph" | "subquery") => {
+    return {
+        thegraph: gql`
+            query($markets: [String!]) {
+                orders(first: 100, where: { market_in: $markets }, orderBy: timestamp, orderDirection: desc) {
+                    id
+                    trader
+                    market
+                    way
+                    orderId
+                    priceX96
+                    volume
+                    limitOrderType
+
+                    timestamp
+                }
+            }
+        `,
+        subquery: undefined,
+    }[schemaType]
+}

--- a/src/queries/histories.ts
+++ b/src/queries/histories.ts
@@ -121,3 +121,34 @@ export const getOrdersQuery = (schemaType: "thegraph" | "subquery") => {
         subquery: undefined,
     }[schemaType]
 }
+
+export const getLimitOrderCreatedExchangesQuery = (schemaType: "thegraph" | "subquery") => {
+    return {
+        thegraph: gql`
+            query($markets: [String!]) {
+                limitOrderCreatedExchanges(
+                    first: 100
+                    where: { market_in: $markets }
+                    orderBy: timestamp
+                    orderDirection: desc
+                ) {
+                    id
+                    exchange
+                    trader
+                    market
+                    isBid
+
+                    base
+                    priceX96
+                    limitOrderType
+                    orderId
+                    baseTaker
+
+                    blockNumberLogIndex
+                    timestamp
+                }
+            }
+        `,
+        subquery: undefined,
+    }[schemaType]
+}

--- a/src/queries/histories.ts
+++ b/src/queries/histories.ts
@@ -152,3 +152,31 @@ export const getLimitOrderCreatedExchangesQuery = (schemaType: "thegraph" | "sub
         subquery: undefined,
     }[schemaType]
 }
+
+export const getLimitOrderSettledsQuery = (schemaType: "thegraph" | "subquery") => {
+    return {
+        thegraph: gql`
+            query($markets: [String!]) {
+                limitOrderSettleds(
+                    first: 100
+                    where: { market_in: $markets }
+                    orderBy: timestamp
+                    orderDirection: desc
+                ) {
+                    id
+                    exchange
+                    trader
+                    market
+
+                    base
+                    quote
+                    realizedPnl
+
+                    blockNumberLogIndex
+                    timestamp
+                }
+            }
+        `,
+        subquery: undefined,
+    }[schemaType]
+}

--- a/src/queries/leaderboard.ts
+++ b/src/queries/leaderboard.ts
@@ -3,8 +3,8 @@ import { gql } from "@apollo/client"
 export const getProfitRatiosQuery = (schemaType: "thegraph" | "subquery") => {
     return {
         thegraph: gql`
-            query($startedAt_gt: [Int!]) {
-                profitRatios(first: 100) {
+            query {
+                profitRatios(first: 1000) {
                     id
                     trader
                     startedAt

--- a/src/util/queries.ts
+++ b/src/util/queries.ts
@@ -1,6 +1,6 @@
 import _ from "lodash"
-import { constants } from "ethers"
-import { bigNum2Big, formattedNumberWithCommas } from "./format"
+import { BigNumber, constants } from "ethers"
+import { bigNum2Big, formattedNumberWithCommas, x96ToBig } from "./format"
 import { formatTime, normalizeToUnixtime } from "./time"
 
 export function cleanUpDepositeds(queryResponse: any) {
@@ -103,6 +103,28 @@ export function cleanUpPositionChangeds(queryResponse: any) {
             // liquidationPenalty
             // liquidationReward
             // insuranceFundReward
+            time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
+            timestamp: values.timestamp,
+        }
+    })
+
+    return _.sortBy(results, (data: any) => -data.timestamp)
+}
+
+export function cleanUpOrders(queryResponse: any) {
+    if (!queryResponse || !queryResponse.orders) return
+
+    const orders = queryResponse.orders
+
+    const results = orders.map((values: any) => {
+        return {
+            trader: values.trader,
+            // market: values.market,
+            way: values.way,
+            orderId: values.orderId,
+            price: formattedNumberWithCommas(x96ToBig(BigNumber.from(values.priceX96), true)),
+            volume: formattedNumberWithCommas(bigNum2Big(values.volume)) + "ETH",
+            limitOrderType: values.limitOrderType,
             time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
             timestamp: values.timestamp,
         }

--- a/src/util/queries.ts
+++ b/src/util/queries.ts
@@ -132,3 +132,25 @@ export function cleanUpOrders(queryResponse: any) {
 
     return _.sortBy(results, (data: any) => -data.timestamp)
 }
+
+export function cleanUpLimitOrderCreatedExchanges(queryResponse: any) {
+    if (!queryResponse || !queryResponse.limitOrderCreatedExchanges) return
+
+    const limitOrderCreatedExchanges = queryResponse.limitOrderCreatedExchanges
+
+    const results = limitOrderCreatedExchanges.map((values: any) => {
+        return {
+            trader: values.trader,
+            // market: values.market,
+            bidOrAsk: values.isBid ? "bid" : "ask",
+            base: formattedNumberWithCommas(bigNum2Big(values.base)),
+            orderId: values.orderId,
+            price: formattedNumberWithCommas(x96ToBig(BigNumber.from(values.priceX96), true)),
+            // limitOrderType: values.limitOrderType,
+            time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
+            timestamp: values.timestamp,
+        }
+    })
+
+    return _.sortBy(results, (data: any) => -data.timestamp)
+}

--- a/src/util/queries.ts
+++ b/src/util/queries.ts
@@ -18,3 +18,20 @@ export function cleanUpDepositeds(queryResponse: any) {
 
     return _.sortBy(results, (data: any) => -data.timestamp)
 }
+
+export function cleanUpWithdrawn(queryResponse: any) {
+    if (!queryResponse || !queryResponse.depositeds) return
+
+    const depositeds = queryResponse.depositeds
+
+    const results = depositeds.map((values: any) => {
+        return {
+            trader: values.trader,
+            amount: formattedNumberWithCommas(bigNum2Big(values.amount)) + "ETH",
+            time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
+            timestamp: values.timestamp,
+        }
+    })
+
+    return _.sortBy(results, (data: any) => -data.timestamp)
+}

--- a/src/util/queries.ts
+++ b/src/util/queries.ts
@@ -20,14 +20,37 @@ export function cleanUpDepositeds(queryResponse: any) {
 }
 
 export function cleanUpWithdrawn(queryResponse: any) {
-    if (!queryResponse || !queryResponse.depositeds) return
+    if (!queryResponse || !queryResponse.withdrawns) return
 
-    const depositeds = queryResponse.depositeds
+    const withdrawns = queryResponse.withdrawns
 
-    const results = depositeds.map((values: any) => {
+    const results = withdrawns.map((values: any) => {
         return {
             trader: values.trader,
             amount: formattedNumberWithCommas(bigNum2Big(values.amount)) + "ETH",
+            time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
+            timestamp: values.timestamp,
+        }
+    })
+
+    return _.sortBy(results, (data: any) => -data.timestamp)
+}
+
+export function cleanUpLiquidityAddedExchanges(queryResponse: any) {
+    if (!queryResponse || !queryResponse.liquidityAddedExchanges) return
+
+    const liquidityAddedExchanges = queryResponse.liquidityAddedExchanges
+
+    const results = liquidityAddedExchanges.map((values: any) => {
+        return {
+            trader: values.trader,
+            market: values.market,
+
+            base: formattedNumberWithCommas(bigNum2Big(values.base)),
+            quote: formattedNumberWithCommas(bigNum2Big(values.quote)),
+            // cumBasePerLiquidityX96: formattedNumberWithCommas(x96ToBig(values.cumBasePerLiquidityX96)),
+            // cumQuotePerLiquidityX96: formattedNumberWithCommas(x96ToBig(values.cumQuotePerLiquidityX96)),
+            liquidity: formattedNumberWithCommas(bigNum2Big(values.liquidity)) + "ETH",
             time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
             timestamp: values.timestamp,
         }

--- a/src/util/queries.ts
+++ b/src/util/queries.ts
@@ -1,4 +1,5 @@
 import _ from "lodash"
+import { constants } from "ethers"
 import { bigNum2Big, formattedNumberWithCommas } from "./format"
 import { formatTime, normalizeToUnixtime } from "./time"
 
@@ -51,6 +52,30 @@ export function cleanUpLiquidityAddedExchanges(queryResponse: any) {
             // cumBasePerLiquidityX96: formattedNumberWithCommas(x96ToBig(values.cumBasePerLiquidityX96)),
             // cumQuotePerLiquidityX96: formattedNumberWithCommas(x96ToBig(values.cumQuotePerLiquidityX96)),
             liquidity: formattedNumberWithCommas(bigNum2Big(values.liquidity)) + "ETH",
+            time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
+            timestamp: values.timestamp,
+        }
+    })
+
+    return _.sortBy(results, (data: any) => -data.timestamp)
+}
+
+export function cleanUpLiquidityRemovedExchanges(queryResponse: any) {
+    if (!queryResponse || !queryResponse.liquidityRemovedExchanges) return
+
+    const liquidityRemovedExchanges = queryResponse.liquidityRemovedExchanges
+
+    const results = liquidityRemovedExchanges.map((values: any) => {
+        return {
+            trader: values.trader,
+            // market: values.market,
+            liquidator: values.liquidator === constants.AddressZero ? "-" : values.liquidator,
+            // base: formattedNumberWithCommas(bigNum2Big(values.base)),
+            // quote: formattedNumberWithCommas(bigNum2Big(values.quote)),
+            liquidity: formattedNumberWithCommas(bigNum2Big(values.liquidity)) + "ETH",
+            // takerBase
+            // takerQuote,
+            realizedPnl: formattedNumberWithCommas(bigNum2Big(values.realizedPnl)) + "ETH",
             time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
             timestamp: values.timestamp,
         }

--- a/src/util/queries.ts
+++ b/src/util/queries.ts
@@ -83,3 +83,30 @@ export function cleanUpLiquidityRemovedExchanges(queryResponse: any) {
 
     return _.sortBy(results, (data: any) => -data.timestamp)
 }
+
+export function cleanUpPositionChangeds(queryResponse: any) {
+    if (!queryResponse || !queryResponse.positionChangeds) return
+
+    const positionChangeds = queryResponse.positionChangeds
+
+    const results = positionChangeds.map((values: any) => {
+        return {
+            trader: values.trader,
+            // market: values.market,
+            // base: formattedNumberWithCommas(bigNum2Big(values.base)),
+            // quote: formattedNumberWithCommas(bigNum2Big(values.quote)),
+            realizedPnl: formattedNumberWithCommas(bigNum2Big(values.realizedPnl)) + "ETH",
+            protocolFee: formattedNumberWithCommas(bigNum2Big(values.protocolFee)) + "ETH",
+            // baseBalancePerShareX96
+            // sharePriceAfterX96
+            // liquidator: values.liquidator === constants.AddressZero ? "-" : values.liquidator,
+            // liquidationPenalty
+            // liquidationReward
+            // insuranceFundReward
+            time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
+            timestamp: values.timestamp,
+        }
+    })
+
+    return _.sortBy(results, (data: any) => -data.timestamp)
+}

--- a/src/util/queries.ts
+++ b/src/util/queries.ts
@@ -154,3 +154,23 @@ export function cleanUpLimitOrderCreatedExchanges(queryResponse: any) {
 
     return _.sortBy(results, (data: any) => -data.timestamp)
 }
+
+export function cleanUpLimitOrderSettleds(queryResponse: any) {
+    if (!queryResponse || !queryResponse.limitOrderSettleds) return
+
+    const limitOrderSettleds = queryResponse.limitOrderSettleds
+
+    const results = limitOrderSettleds.map((values: any) => {
+        return {
+            trader: values.trader,
+            // market: values.market,
+            base: formattedNumberWithCommas(bigNum2Big(values.base)),
+            quote: formattedNumberWithCommas(bigNum2Big(values.quote)),
+            realizedPnl: formattedNumberWithCommas(bigNum2Big(values.realizedPnl)) + "ETH",
+            time: formatTime(normalizeToUnixtime(Number(values.timestamp)), true),
+            timestamp: values.timestamp,
+        }
+    })
+
+    return _.sortBy(results, (data: any) => -data.timestamp)
+}


### PR DESCRIPTION
Done 

- fixed pagination bugs for leaderboard
- added histories table for below list

export type HistoryDataType =
    | "Deposited"
    | "Withdrawn"
    | "LiquidityAddedExchanges"
    | "LiquidityRemovedExchanges"
    | "PositionChangeds"
    | "Orders"
    | "LimitOrderCreatedExchanges"
    | "LimitOrderSettleds"